### PR TITLE
feat: add sample for use_sim

### DIFF
--- a/caret_demos/launch/end_to_end_sample_with_lttng_session_use_sim.launch.py
+++ b/caret_demos/launch/end_to_end_sample_with_lttng_session_use_sim.launch.py
@@ -1,0 +1,22 @@
+import launch
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+from tracetools_launch.action import Trace
+
+
+def generate_launch_description():
+    use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
+    use_rosbag = launch.substitutions.LaunchConfiguration('use_rosbag', default='false')
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument("use_sim_time", default_value="false"),
+        launch.actions.DeclareLaunchArgument("use_rosbag", default_value="false"),
+        Trace(
+            session_name='end_to_end_sample',
+            events_kernel=[],
+            events_ust=['ros2*']
+        ),
+        launch_ros.actions.Node(
+            package='caret_demos', executable='end_to_end_sample', output='screen',
+            parameters=[{'use_sim_time': use_sim_time}, {'use_rosbag': use_rosbag}]),
+    ])

--- a/caret_demos/src/end_to_end_sample.cpp
+++ b/caret_demos/src/end_to_end_sample.cpp
@@ -139,6 +139,14 @@ public:
   SensorDummy(std::string node_name, std::string topic_name, int period_ms)
   : Node(node_name)
   {
+    this->declare_parameter<bool>("use_rosbag", false);
+    bool use_rosbag;
+    this->get_parameter("use_rosbag", use_rosbag);
+    RCLCPP_INFO(this->get_logger(), "use_rosbag = %d", use_rosbag);
+    if (use_rosbag) {
+      return;
+    }
+
     auto period = std::chrono::milliseconds(period_ms);
 
     auto callback = [&]() {

--- a/caret_demos/src/end_to_end_sample.cpp
+++ b/caret_demos/src/end_to_end_sample.cpp
@@ -140,7 +140,7 @@ public:
   : Node(node_name)
   {
     this->declare_parameter<bool>("use_rosbag", false);
-    bool use_rosbag;
+    bool use_rosbag = false;
     this->get_parameter("use_rosbag", use_rosbag);
     RCLCPP_INFO(this->get_logger(), "use_rosbag = %d", use_rosbag);
     if (use_rosbag) {


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

I modified sample code, so that it can be used to demonstrate use_sim in CARET_doc. This modification should make no effect on current implementation. My only concern is this modification make the current code little bit complicated. Demo code should be simple though..

Reference: https://tier4.github.io/CARET_doc/pr-84/recording/sim_time/#sample-project-to-use-sim_time  (WIP, and this branch will disappear in the future)