### PR TITLE
feat: add take and generice communication node

### DIFF
--- a/caret_demos/CMakeLists.txt
+++ b/caret_demos/CMakeLists.txt
@@ -17,9 +17,13 @@ add_executable(relay
   src/relay.cpp)
 ament_target_dependencies(relay rclcpp sensor_msgs)
 
+add_executable(advanced_demo src/advanced_demo.cpp)
+ament_target_dependencies(advanced_demo rclcpp sensor_msgs)
+
 install(TARGETS
   end_to_end_sample
   relay
+  advanced_demo
   DESTINATION lib/${PROJECT_NAME})
 
 # install launch files

--- a/caret_demos/CMakeLists.txt
+++ b/caret_demos/CMakeLists.txt
@@ -9,16 +9,17 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-add_executable(end_to_end_sample
-  src/end_to_end_sample.cpp)
+add_executable(end_to_end_sample src/end_to_end_sample.cpp)
 ament_target_dependencies(end_to_end_sample rclcpp sensor_msgs)
 
-add_executable(relay
-  src/relay.cpp)
+add_executable(relay src/relay.cpp)
 ament_target_dependencies(relay rclcpp sensor_msgs)
 
 add_executable(advanced_demo src/advanced_demo.cpp)
-ament_target_dependencies(advanced_demo rclcpp sensor_msgs)
+ament_target_dependencies(advanced_demo 
+    rclcpp 
+    sensor_msgs
+)
 
 install(TARGETS
   end_to_end_sample
@@ -26,11 +27,7 @@ install(TARGETS
   advanced_demo
   DESTINATION lib/${PROJECT_NAME})
 
-# install launch files
-install(DIRECTORY
-  launch
-  DESTINATION share/${PROJECT_NAME}
-  )
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/caret_demos/launch/advanced_demo.launch.py
+++ b/caret_demos/launch/advanced_demo.launch.py
@@ -1,0 +1,20 @@
+import launch
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+
+def generate_launch_description():
+    use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
+    use_rosbag = launch.substitutions.LaunchConfiguration('use_rosbag', default='false')
+
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument("use_sim_time", default_value="false"),
+        launch.actions.DeclareLaunchArgument("use_rosbag", default_value="false"),
+
+        launch_ros.actions.Node(
+            package='caret_demos',
+            executable='advanced_demo',
+            output='screen',
+            parameters=[{'use_sim_time': use_sim_time}, {'use_rosbag': use_rosbag}]
+        ),
+    ])

--- a/caret_demos/src/advanced_demo.cpp
+++ b/caret_demos/src/advanced_demo.cpp
@@ -2,6 +2,8 @@
 #include <memory>
 #include <vector>
 #include <random>
+#include <string>
+#include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/generic_publisher.hpp"
@@ -12,163 +14,196 @@
 
 using namespace std::chrono_literals;
 
+std::string spaces(int count) {
+  return std::string(std::max(0, count), ' ');
+}
+
 std::chrono::milliseconds lognormal_distribution(double max)
 {
   static std::random_device seed_gen;
   static std::default_random_engine engine(seed_gen());
   static std::lognormal_distribution<> dist(1.1, 1.7);
-
   int sleep_ms = std::max(std::min(dist(engine), max), 20.0);
   return std::chrono::milliseconds(sleep_ms);
 }
 
-class NoDependencyNode : public rclcpp::Node
-{
+
+class SensorDummy : public rclcpp::Node {
 public:
-  NoDependencyNode(std::string node_name, std::string sub_topic_name, std::string pub_topic_name)
-  : Node(node_name)
-  {
-    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_topic_name, QOS_HISTORY_SIZE);
-    sub_ = create_subscription<sensor_msgs::msg::Image>(
-      sub_topic_name, QOS_HISTORY_SIZE, [&](sensor_msgs::msg::Image::UniquePtr msg)
-      {
-        rclcpp::sleep_for(lognormal_distribution(200));
-        pub_->publish(std::move(msg));
-      });
-  }
-
-private:
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
-};
-
-class ActuatorDummy : public rclcpp::Node
-{
-public:
-  ActuatorDummy(std::string node_name, std::string sub_topic_name)
-  : Node(node_name)
-  {
-    sub_ = create_subscription<sensor_msgs::msg::Image>(
-      sub_topic_name, QOS_HISTORY_SIZE,
-      [this](sensor_msgs::msg::Image::UniquePtr msg)
-      {
-        rclcpp::sleep_for(lognormal_distribution(80));
-        (void)msg;
-      }
-    );
-  }
-
-private:
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
-};
-
-class SensorDummy : public rclcpp::Node
-{
-public:
-  SensorDummy(std::string node_name, std::string topic_name, int period_ms)
-  : Node(node_name)
-  {
-    this->declare_parameter<bool>("use_rosbag", false);
-    bool use_rosbag = false;
-    this->get_parameter("use_rosbag", use_rosbag);
-    if (use_rosbag) return;
-
-    pub_ = create_publisher<sensor_msgs::msg::Image>(topic_name, QOS_HISTORY_SIZE);
-    timer_ = create_wall_timer(std::chrono::milliseconds(period_ms), [&]() {
+  SensorDummy(std::string name, std::string pub_t, int period, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
+  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
+    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
+    timer_ = create_wall_timer(std::chrono::milliseconds(period), [this]() {
         auto msg = std::make_unique<sensor_msgs::msg::Image>();
-        rclcpp::sleep_for(lognormal_distribution(50));
         msg->header.stamp = now();
+        RCLCPP_INFO(this->get_logger(), "%s [Step %d Sensor] Publish >>>", spaces(col_).c_str(), idx_);
+        rclcpp::sleep_for(lognormal_distribution(delay_));
         pub_->publish(std::move(msg));
       });
   }
-
 private:
+  int idx_, col_; double delay_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 
 class GenericRelayNode : public rclcpp::Node {
 public:
-  GenericRelayNode(std::string node_name, std::string sub_topic, std::string pub_topic, std::string type)
-  : Node(node_name) {
-    pub_ = create_generic_publisher(pub_topic, type, QOS_HISTORY_SIZE);
-    sub_ = create_generic_subscription(sub_topic, type, QOS_HISTORY_SIZE,
+  GenericRelayNode(std::string name, std::string sub_t, std::string pub_t, std::string type, int idx, int col, const rclcpp::NodeOptions & opt)
+  : Node(name, opt), idx_(idx), col_(col) {
+    pub_ = create_generic_publisher(pub_t, type, QOS_HISTORY_SIZE);
+    sub_ = create_generic_subscription(sub_t, type, QOS_HISTORY_SIZE,
       [this](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+        RCLCPP_INFO(this->get_logger(), "%s [Step %d Generic] Relay", spaces(col_).c_str(), idx_);
         pub_->publish(*msg);
       });
   }
 private:
+  int idx_, col_;
   rclcpp::GenericPublisher::SharedPtr pub_;
   rclcpp::GenericSubscription::SharedPtr sub_;
 };
 
-// TakePollingNode
+class NoDependencyNode : public rclcpp::Node {
+public:
+  NoDependencyNode(std::string name, std::string sub_t, std::string pub_t, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
+  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
+    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
+    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE,
+      [this](sensor_msgs::msg::Image::UniquePtr msg) {
+        RCLCPP_INFO(this->get_logger(), "%s [Step %d Standard] Callback Received", spaces(col_).c_str(), idx_);
+        rclcpp::sleep_for(lognormal_distribution(delay_));
+        pub_->publish(std::move(msg));
+      });
+  }
+private:
+  int idx_, col_; double delay_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
+};
+
 class TakePollingNode : public rclcpp::Node {
 public:
-  TakePollingNode(std::string node_name, std::string sub_topic, std::string trigger_topic, std::string pub_topic, int period_ms) 
-  : Node(node_name) {
-    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_topic, QOS_HISTORY_SIZE);
-    polling_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
-
-    rclcpp::SubscriptionOptions options;
-    options.callback_group = polling_group_;
+  TakePollingNode(std::string name, std::string sub_t, std::string pub_t, std::string trigger_t, int ms, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
+  : Node(name, opt), idx_(idx), col_(col), delay_(delay), received_(false) {
+    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
+    auto group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    rclcpp::SubscriptionOptions s_opt; s_opt.callback_group = group;
+    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE, [](sensor_msgs::msg::Image::UniquePtr){}, s_opt);
     
-    sub_ = create_subscription<sensor_msgs::msg::Image>(
-      sub_topic, QOS_HISTORY_SIZE, [](sensor_msgs::msg::Image::UniquePtr) {}, options);
-
-    if (trigger_topic.empty()) {
-      timer_ = create_wall_timer(std::chrono::milliseconds(period_ms), [this]() { this->execute_take(); });
+    if (trigger_t.empty()) {
+      timer_ = create_wall_timer(std::chrono::milliseconds(ms), [this](){ execute(true); });
     } else {
-      sub_trigger_ = create_subscription<sensor_msgs::msg::Image>(
-        trigger_topic, QOS_HISTORY_SIZE, [this](sensor_msgs::msg::Image::UniquePtr) { this->execute_take(); });
+      sub_trig_ = create_subscription<sensor_msgs::msg::Image>(trigger_t, QOS_HISTORY_SIZE, [this](sensor_msgs::msg::Image::UniquePtr){ execute(false); });
     }
   }
-
 private:
-  void execute_take() {
-    sensor_msgs::msg::Image msg; 
-    rclcpp::MessageInfo msg_info;
-    if (sub_->take(msg, msg_info)) {
-      auto pub_msg = std::make_unique<sensor_msgs::msg::Image>(msg);
-      rclcpp::sleep_for(lognormal_distribution(45));
-      pub_->publish(std::move(pub_msg));
+  void execute(bool is_timer) {
+    sensor_msgs::msg::Image msg; rclcpp::MessageInfo info;
+    if (sub_->take(msg, info)) {
+      received_ = true;
+      RCLCPP_INFO(this->get_logger(), "%s [Step %d Take:%s] Success", spaces(col_).c_str(), idx_, is_timer ? "Timer" : "Topic");
+      rclcpp::sleep_for(lognormal_distribution(delay_));
+      pub_->publish(std::make_unique<sensor_msgs::msg::Image>(msg));
+    } else if (is_timer && received_) {
+      RCLCPP_INFO(this->get_logger(), "%s [Step %d Take:Timer] No data", spaces(col_).c_str(), idx_);
     }
   }
+  int idx_, col_; double delay_; bool received_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_, sub_trigger_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_, sub_trig_;
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::CallbackGroup::SharedPtr polling_group_;
 };
+
+class ActuatorDummy : public rclcpp::Node {
+public:
+  ActuatorDummy(std::string name, std::string sub_t, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
+  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
+    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE,
+      [this](sensor_msgs::msg::Image::UniquePtr){
+        RCLCPP_INFO(this->get_logger(), "%s [Step %d Actuator] Reached <<<", spaces(col_).c_str(), idx_);
+        rclcpp::sleep_for(lognormal_distribution(delay_));
+      });
+  }
+private:
+  int idx_, col_; double delay_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
+};
+
 
 int main(int argc, char * argv[]) {
   rclcpp::init(argc, argv);
   auto executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   std::vector<std::shared_ptr<rclcpp::Node>> nodes;
 
-  rclcpp::NodeOptions intra_proc_options;
-  intra_proc_options.use_intra_process_comms(true);
+  struct NodeBaseConfig {
+    std::string name;
+    std::string sub_t;
+    std::string pub_t;
+    int step;
+    double max_delay;
+  };
 
+  std::vector<NodeBaseConfig> configs = {
+    {"sensor_dummy_node",       "",             "/topic1",       1,  40.0},
+    {"generic_relay",           "/topic1",      "/topic_gen",    2,   0.0},
+    {"filter_node",             "/topic_gen",   "/topic2",       3, 150.0},
+    {"take_polling_node",       "/topic2",      "/topic_trig",   4,  40.0},
+    {"take_polling_node_timer", "/topic_trig",  "/topic_polled", 5,  40.0},
+    {"actuator_dummy_node",     "/topic_polled", "",             6,  60.0}
+  };
+
+  // indentation for log
+  size_t max_name_len = 0;
+  for (const auto& c : configs) max_name_len = std::max(max_name_len, c.name.length());
+  auto get_col = [&](const NodeBaseConfig& c) {
+    return static_cast<int>(max_name_len - c.name.length()) + (c.step * 2) + 1;
+  };
+
+  rclcpp::NodeOptions intra_on;  intra_on.use_intra_process_comms(true);
+  rclcpp::NodeOptions intra_off; intra_off.use_intra_process_comms(false);
+
+  // Step 1: Sensor (Inter-process)
   nodes.emplace_back(std::make_shared<SensorDummy>(
-    "sensor_dummy_node", "/topic1", 100, intra_proc_options)
-  );
+    configs[0].name, configs[0].pub_t, 300, configs[0].max_delay, 
+    configs[0].step, get_col(configs[0]), 
+    intra_off));
 
+  // Step 2: Generic Relay (Inter-process)
   nodes.emplace_back(std::make_shared<GenericRelayNode>(
-    "generic_relay", "/topic1", "/topic_gen", "sensor_msgs/msg/Image", intra_proc_options)
-  );
+    configs[1].name, configs[1].sub_t, configs[1].pub_t, "sensor_msgs/msg/Image", 
+    configs[1].step, get_col(configs[1]), 
+    intra_off));
 
-  nodes.emplace_back(std::make_shared<NoDependencyNode>("filter_node", "/topic_gen", "/topic2"));
-
-  // take: topic trigger
+  // Step 3: Filter (Inter-process)
+  nodes.emplace_back(std::make_shared<NoDependencyNode>(
+    configs[2].name, configs[2].sub_t, configs[2].pub_t, configs[2].max_delay, 
+    configs[2].step, get_col(configs[2]), 
+    intra_off));
+  
+  // Step 4: Take Topic Trigger (Inter-process)
   nodes.emplace_back(std::make_shared<TakePollingNode>(
-    "take_polling_node", "/topic2", "/topic2", "/topic_trig", 100));
-
-  // take: timer trigger
+    configs[3].name, configs[3].sub_t, configs[3].pub_t, "/topic_gen", 100, 
+    configs[3].max_delay, configs[3].step, get_col(configs[3]), 
+    intra_off));
+  
+  // Step 5: Take Polling Timer Trigger (Intra-process)
+  // Receive from Step 4(Inter), and send to Step 6(Intra)
   nodes.emplace_back(std::make_shared<TakePollingNode>(
-    "take_polling_node_timer", "/topic_trig", "", "/topic_polled", 100));
-
-  nodes.emplace_back(std::make_shared<ActuatorDummy>("actuator_dummy_node", "/topic_polled"));
+    configs[4].name, configs[4].sub_t, configs[4].pub_t, "", 150, 
+    configs[4].max_delay, configs[4].step, get_col(configs[4]), 
+    intra_on));
+  
+  // Step 6: Actuator (Intra-process)
+  // Receive from Step 5(Intra)
+  nodes.emplace_back(std::make_shared<ActuatorDummy>(
+    configs[5].name, configs[5].sub_t, configs[5].max_delay, 
+    configs[5].step, get_col(configs[5]), 
+    intra_on));
 
   for (auto & node : nodes) { executor->add_node(node); }
+  
+  RCLCPP_INFO(rclcpp::get_logger("main"), "===== Final Experiment Configuration (Inter x Intra) Started =====");
   executor->spin();
   rclcpp::shutdown();
   return 0;

--- a/caret_demos/src/advanced_demo.cpp
+++ b/caret_demos/src/advanced_demo.cpp
@@ -5,6 +5,12 @@
 #include <thread>
 
 #include "rclcpp/rclcpp.hpp"
+// for humble
+#if __has_include("rclcpp/serialization.hpp")
+  #include "rclcpp/serialization.hpp"
+  #define IS_HUMBLE_OR_OLDER
+#endif
+
 #include "rclcpp/generic_publisher.hpp"
 #include "rclcpp/generic_subscription.hpp"
 #include "sensor_msgs/msg/image.hpp"
@@ -34,33 +40,29 @@ int main(int argc, char * argv[]) {
     auto sub_raw = intra_relay_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_raw", 10, [intra_relay_node, pub_filtered](sensor_msgs::msg::Image::UniquePtr msg){
             RCLCPP_INFO(intra_relay_node->get_logger(),
-                "        [Step 2] Intra Relay: Recv /image_raw -> Pub /image_filtered_intra (Intra-process)");
+                "         [Step 2] Intra Relay: Recv /image_raw -> Pub /image_filtered_intra (Intra-process)");
             pub_filtered->publish(std::move(msg));
         });
 
     // --- Node 3: Data Serializer ---
     auto data_serializer_node = std::make_shared<rclcpp::Node>("data_serializer_node");
-    // Generic for take
     auto pub_serialized = data_serializer_node->create_generic_publisher(
         "/image_serialized", "sensor_msgs/msg/Image", 10);
-    // Normal Publisher torigger for take
     auto pub_trigger = data_serializer_node->create_publisher<sensor_msgs::msg::Image>(
         "/image_trigger", 10);
 
     auto sub_filtered = data_serializer_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_filtered_intra", 10, 
         [data_serializer_node, pub_serialized, pub_trigger](sensor_msgs::msg::Image::UniquePtr msg) {
-            // 1. Publish serialized data
             auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
             rclcpp::Serialization<sensor_msgs::msg::Image> ser;
             ser.serialize_message(msg.get(), ser_msg.get());
             pub_serialized->publish(*ser_msg);
 
-            // 2. Publish normal data (trigger)
             sensor_msgs::msg::Image trigger_msg;
             pub_trigger->publish(trigger_msg);
 
-            RCLCPP_INFO(data_serializer_node->get_logger(), "    [Step 3] Data Serializer: Pub Data & Trigger");
+            RCLCPP_INFO(data_serializer_node->get_logger(), "     [Step 3] Data Serializer: Pub Data & Trigger");
         });
 
     // --- Node 4: Generic Relay ---
@@ -70,22 +72,20 @@ int main(int argc, char * argv[]) {
     auto group_relay = generic_relay_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
     auto opt_relay = rclcpp::SubscriptionOptions();
     opt_relay.callback_group = group_relay;
-    // rclcpp::CallbackGroupType::MutuallyExclusive is false
+    
     auto sub_data_gen = generic_relay_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_serialized", 10, [](sensor_msgs::msg::Image::UniquePtr){}, opt_relay);
 
-    // trigger
     auto sub_trig = generic_relay_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_trigger", 10, 
         [generic_relay_node, sub_data_gen, pub_relay](sensor_msgs::msg::Image::UniquePtr /*trigger_msg*/) {
-            RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] Generic Relay: Triggered by /image_trigger.");
+            RCLCPP_INFO(generic_relay_node->get_logger(), "       [Step 4] Generic Relay: Triggered by /image_trigger.");
 
             auto img_msg = std::make_shared<sensor_msgs::msg::Image>();
             rclcpp::MessageInfo info;
             
-            // take from sub_data_gen
             if (sub_data_gen->take(*img_msg, info)) {
-                RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] SUCCESS: Take Success & Pub /image_relay");
+                RCLCPP_INFO(generic_relay_node->get_logger(), "       [Step 4] SUCCESS: Take Success & Pub /image_relay");
                 pub_relay->publish(*img_msg);
             }
         });
@@ -103,36 +103,56 @@ int main(int argc, char * argv[]) {
         sensor_msgs::msg::Image msg; rclcpp::MessageInfo info;
         if (sub_data_relay->take(msg, info)) {
             RCLCPP_INFO(inter_take_node->get_logger(),
-                "         [Step 5] Inter Take Node: Timer triggered take(/image_relay) -> Pub /image_inter_buffered");
+                "          [Step 5] Inter Take Node: Timer triggered take(/image_relay) -> Pub /image_inter_buffered");
             pub_buffered->publish(msg);
         }
     });
 
     // --- Node 6: Intra Take Node ---
+#ifdef IS_HUMBLE_OR_OLDER
+    auto intra_take_node = std::make_shared<rclcpp::Node>(
+        "intra_take_node", rclcpp::NodeOptions().use_intra_process_comms(false));
+#else
     auto intra_take_node = std::make_shared<rclcpp::Node>(
         "intra_take_node", rclcpp::NodeOptions().use_intra_process_comms(true));
+#endif
+
     auto pub_latched = intra_take_node->create_publisher<sensor_msgs::msg::Image>(
         "/image_transient_local", transient_local_qos);
     auto group_intra = intra_take_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
     auto opt_intra = rclcpp::SubscriptionOptions();
     opt_intra.callback_group = group_intra;
+
+#ifndef IS_HUMBLE_OR_OLDER
     ENABLE_INTRA_PROCESS(opt_intra);
+#endif
 
     auto sub_data_intra = intra_take_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_filtered_intra", 10, 
         [pub_latched](const sensor_msgs::msg::Image::SharedPtr msg){ pub_latched->publish(*msg); }, opt_intra);
 
     auto sub_trig_inter = intra_take_node->create_subscription<sensor_msgs::msg::Image>(
-        "/image_inter_buffered", 10, [intra_take_node, sub_data_intra](sensor_msgs::msg::Image::UniquePtr){
+        "/image_inter_buffered", 10, [intra_take_node, sub_data_intra, pub_latched](sensor_msgs::msg::Image::UniquePtr){
             RCLCPP_INFO(intra_take_node->get_logger(),
-                "         [Step 6] Intra Take Node: Topic triggered take(/image_filtered_intra).");
+                "          [Step 6] Intra Take Node: Topic triggered take(/image_filtered_intra).");
+#ifdef IS_HUMBLE_OR_OLDER
+            // Humble path
+            auto img_msg = std::make_shared<sensor_msgs::msg::Image>();
+            rclcpp::MessageInfo info;
+            if (sub_data_intra->take(*img_msg, info)) {
+                RCLCPP_INFO(intra_take_node->get_logger(), "          [Step 6] SUCCESS: Pub /image_transient_local (Inter-process)");
+                pub_latched->publish(*img_msg);
+            }
+#else
+            // Jazzy path
             auto ipw = sub_data_intra->get_intra_process_waitable();
             if (ipw && ipw->is_ready(nullptr)) {
                 auto data = ipw->take_data();
                 if (data && (ipw->execute(data), true)) {
-                    RCLCPP_INFO(intra_take_node->get_logger(), "         [Step 6] SUCCESS: Pub /image_transient_local");
+                    RCLCPP_INFO(intra_take_node->get_logger(), "          [Step 6] SUCCESS: Pub /image_transient_local (Intra-process)");
                 }
             }
+#endif
         });
 
     // --- Node 7: Timer Take Node ---
@@ -149,7 +169,7 @@ int main(int argc, char * argv[]) {
         rclcpp::MessageInfo info;
         if (sub_data_latched->take(*msg, info)) {
             RCLCPP_INFO(timer_take_node->get_logger(),
-                "         [Step 7] Timer Take Node: Timer triggered take(/image_transient_local) -> Pub /image_final");
+                "          [Step 7] Timer Take Node: Timer triggered take(/image_transient_local) -> Pub /image_final");
             pub_final->publish(*msg);
         }
     });
@@ -158,7 +178,7 @@ int main(int argc, char * argv[]) {
     auto dummy_actuator_node = std::make_shared<rclcpp::Node>("dummy_actuator_node");
     auto sub_final = dummy_actuator_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_final", 10, [&](const sensor_msgs::msg::Image::SharedPtr){
-            RCLCPP_INFO(dummy_actuator_node->get_logger(), "     [Step 8] Dummy Actuator: Recv /image_final. Path Complete! <<<");
+            RCLCPP_INFO(dummy_actuator_node->get_logger(), "      [Step 8] Dummy Actuator: Recv /image_final. Path Complete! <<<");
         });
 
     // --- Execution ---

--- a/caret_demos/src/advanced_demo.cpp
+++ b/caret_demos/src/advanced_demo.cpp
@@ -1,0 +1,175 @@
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <random>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/generic_publisher.hpp"
+#include "rclcpp/generic_subscription.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+#define QOS_HISTORY_SIZE 10
+
+using namespace std::chrono_literals;
+
+std::chrono::milliseconds lognormal_distribution(double max)
+{
+  static std::random_device seed_gen;
+  static std::default_random_engine engine(seed_gen());
+  static std::lognormal_distribution<> dist(1.1, 1.7);
+
+  int sleep_ms = std::max(std::min(dist(engine), max), 20.0);
+  return std::chrono::milliseconds(sleep_ms);
+}
+
+class NoDependencyNode : public rclcpp::Node
+{
+public:
+  NoDependencyNode(std::string node_name, std::string sub_topic_name, std::string pub_topic_name)
+  : Node(node_name)
+  {
+    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_topic_name, QOS_HISTORY_SIZE);
+    sub_ = create_subscription<sensor_msgs::msg::Image>(
+      sub_topic_name, QOS_HISTORY_SIZE, [&](sensor_msgs::msg::Image::UniquePtr msg)
+      {
+        rclcpp::sleep_for(lognormal_distribution(200));
+        pub_->publish(std::move(msg));
+      });
+  }
+
+private:
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
+};
+
+class ActuatorDummy : public rclcpp::Node
+{
+public:
+  ActuatorDummy(std::string node_name, std::string sub_topic_name)
+  : Node(node_name)
+  {
+    sub_ = create_subscription<sensor_msgs::msg::Image>(
+      sub_topic_name, QOS_HISTORY_SIZE,
+      [this](sensor_msgs::msg::Image::UniquePtr msg)
+      {
+        rclcpp::sleep_for(lognormal_distribution(80));
+        (void)msg;
+      }
+    );
+  }
+
+private:
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
+};
+
+class SensorDummy : public rclcpp::Node
+{
+public:
+  SensorDummy(std::string node_name, std::string topic_name, int period_ms)
+  : Node(node_name)
+  {
+    this->declare_parameter<bool>("use_rosbag", false);
+    bool use_rosbag = false;
+    this->get_parameter("use_rosbag", use_rosbag);
+    if (use_rosbag) return;
+
+    pub_ = create_publisher<sensor_msgs::msg::Image>(topic_name, QOS_HISTORY_SIZE);
+    timer_ = create_wall_timer(std::chrono::milliseconds(period_ms), [&]() {
+        auto msg = std::make_unique<sensor_msgs::msg::Image>();
+        rclcpp::sleep_for(lognormal_distribution(50));
+        msg->header.stamp = now();
+        pub_->publish(std::move(msg));
+      });
+  }
+
+private:
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+class GenericRelayNode : public rclcpp::Node {
+public:
+  GenericRelayNode(std::string node_name, std::string sub_topic, std::string pub_topic, std::string type)
+  : Node(node_name) {
+    pub_ = create_generic_publisher(pub_topic, type, QOS_HISTORY_SIZE);
+    sub_ = create_generic_subscription(sub_topic, type, QOS_HISTORY_SIZE,
+      [this](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+        pub_->publish(*msg);
+      });
+  }
+private:
+  rclcpp::GenericPublisher::SharedPtr pub_;
+  rclcpp::GenericSubscription::SharedPtr sub_;
+};
+
+// TakePollingNode
+class TakePollingNode : public rclcpp::Node {
+public:
+  TakePollingNode(std::string node_name, std::string sub_topic, std::string trigger_topic, std::string pub_topic, int period_ms) 
+  : Node(node_name) {
+    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_topic, QOS_HISTORY_SIZE);
+    polling_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = polling_group_;
+    
+    sub_ = create_subscription<sensor_msgs::msg::Image>(
+      sub_topic, QOS_HISTORY_SIZE, [](sensor_msgs::msg::Image::UniquePtr) {}, options);
+
+    if (trigger_topic.empty()) {
+      timer_ = create_wall_timer(std::chrono::milliseconds(period_ms), [this]() { this->execute_take(); });
+    } else {
+      sub_trigger_ = create_subscription<sensor_msgs::msg::Image>(
+        trigger_topic, QOS_HISTORY_SIZE, [this](sensor_msgs::msg::Image::UniquePtr) { this->execute_take(); });
+    }
+  }
+
+private:
+  void execute_take() {
+    sensor_msgs::msg::Image msg; 
+    rclcpp::MessageInfo msg_info;
+    if (sub_->take(msg, msg_info)) {
+      auto pub_msg = std::make_unique<sensor_msgs::msg::Image>(msg);
+      rclcpp::sleep_for(lognormal_distribution(45));
+      pub_->publish(std::move(pub_msg));
+    }
+  }
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_, sub_trigger_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::CallbackGroup::SharedPtr polling_group_;
+};
+
+int main(int argc, char * argv[]) {
+  rclcpp::init(argc, argv);
+  auto executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  std::vector<std::shared_ptr<rclcpp::Node>> nodes;
+
+  rclcpp::NodeOptions intra_proc_options;
+  intra_proc_options.use_intra_process_comms(true);
+
+  nodes.emplace_back(std::make_shared<SensorDummy>(
+    "sensor_dummy_node", "/topic1", 100, intra_proc_options)
+  );
+
+  nodes.emplace_back(std::make_shared<GenericRelayNode>(
+    "generic_relay", "/topic1", "/topic_gen", "sensor_msgs/msg/Image", intra_proc_options)
+  );
+
+  nodes.emplace_back(std::make_shared<NoDependencyNode>("filter_node", "/topic_gen", "/topic2"));
+
+  // take: topic trigger
+  nodes.emplace_back(std::make_shared<TakePollingNode>(
+    "take_polling_node", "/topic2", "/topic2", "/topic_trig", 100));
+
+  // take: timer trigger
+  nodes.emplace_back(std::make_shared<TakePollingNode>(
+    "take_polling_node_timer", "/topic_trig", "", "/topic_polled", 100));
+
+  nodes.emplace_back(std::make_shared<ActuatorDummy>("actuator_dummy_node", "/topic_polled"));
+
+  for (auto & node : nodes) { executor->add_node(node); }
+  executor->spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/caret_demos/src/advanced_demo.cpp
+++ b/caret_demos/src/advanced_demo.cpp
@@ -22,7 +22,7 @@ int main(int argc, char * argv[]) {
     // --- Node 1: Sensor Simulator ---
     auto sensor_simulator_node = std::make_shared<rclcpp::Node>("sensor_simulator_node");
     auto pub_raw = sensor_simulator_node->create_publisher<sensor_msgs::msg::Image>("/image_raw", 10);
-    auto timer_300ms = sensor_simulator_node->create_wall_timer(300ms, [&](){
+    auto timer_100ms = sensor_simulator_node->create_wall_timer(100ms, [sensor_simulator_node, pub_raw](){
         RCLCPP_INFO(sensor_simulator_node->get_logger(), "[Step 1] Sensor Start: Pub /image_raw (Inter-process) >>>");
         pub_raw->publish(std::make_unique<sensor_msgs::msg::Image>());
     });
@@ -32,7 +32,7 @@ int main(int argc, char * argv[]) {
         "intra_relay_node", rclcpp::NodeOptions().use_intra_process_comms(true));
     auto pub_filtered = intra_relay_node->create_publisher<sensor_msgs::msg::Image>("/image_filtered_intra", 10);
     auto sub_raw = intra_relay_node->create_subscription<sensor_msgs::msg::Image>(
-        "/image_raw", 10, [&](sensor_msgs::msg::Image::UniquePtr msg){
+        "/image_raw", 10, [intra_relay_node, pub_filtered](sensor_msgs::msg::Image::UniquePtr msg){
             RCLCPP_INFO(intra_relay_node->get_logger(),
                 "        [Step 2] Intra Relay: Recv /image_raw -> Pub /image_filtered_intra (Intra-process)");
             pub_filtered->publish(std::move(msg));
@@ -40,37 +40,53 @@ int main(int argc, char * argv[]) {
 
     // --- Node 3: Data Serializer ---
     auto data_serializer_node = std::make_shared<rclcpp::Node>("data_serializer_node");
+    // Generic for take
     auto pub_serialized = data_serializer_node->create_generic_publisher(
         "/image_serialized", "sensor_msgs/msg/Image", 10);
+    // Normal Publisher torigger for take
+    auto pub_trigger = data_serializer_node->create_publisher<sensor_msgs::msg::Image>(
+        "/image_trigger", 10);
+
     auto sub_filtered = data_serializer_node->create_subscription<sensor_msgs::msg::Image>(
-        "/image_filtered_intra", 10, [&](sensor_msgs::msg::Image::UniquePtr msg){
-            RCLCPP_INFO(data_serializer_node->get_logger(),
-                "    [Step 3] Data Serializer: Recv /image_filtered_intra -> Pub Generic /image_serialized");
+        "/image_filtered_intra", 10, 
+        [data_serializer_node, pub_serialized, pub_trigger](sensor_msgs::msg::Image::UniquePtr msg) {
+            // 1. Publish serialized data
             auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
             rclcpp::Serialization<sensor_msgs::msg::Image> ser;
             ser.serialize_message(msg.get(), ser_msg.get());
             pub_serialized->publish(*ser_msg);
+
+            // 2. Publish normal data (trigger)
+            sensor_msgs::msg::Image trigger_msg;
+            pub_trigger->publish(trigger_msg);
+
+            RCLCPP_INFO(data_serializer_node->get_logger(), "    [Step 3] Data Serializer: Pub Data & Trigger");
         });
 
     // --- Node 4: Generic Relay ---
     auto generic_relay_node = std::make_shared<rclcpp::Node>("generic_relay_node");
     auto pub_relay = generic_relay_node->create_publisher<sensor_msgs::msg::Image>("/image_relay", 10);
-    auto group_relay = generic_relay_node->create_callback_group(
-        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+    auto group_relay = generic_relay_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
     auto opt_relay = rclcpp::SubscriptionOptions();
     opt_relay.callback_group = group_relay;
-    
-    auto sub_data_gen = generic_relay_node->create_generic_subscription(
-        "/image_serialized", "sensor_msgs/msg/Image", 10,
-        [](std::shared_ptr<rclcpp::SerializedMessage>){}, opt_relay);
-    auto sub_trig_gen = generic_relay_node->create_generic_subscription(
-        "/image_serialized", "sensor_msgs/msg/Image", 10, [&](std::shared_ptr<rclcpp::SerializedMessage>){
-            RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] Generic Relay: Triggered by /image_serialized.");
-            auto msg = sub_data_gen->create_serialized_message();
+    // rclcpp::CallbackGroupType::MutuallyExclusive is false
+    auto sub_data_gen = generic_relay_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_serialized", 10, [](sensor_msgs::msg::Image::UniquePtr){}, opt_relay);
+
+    // trigger
+    auto sub_trig = generic_relay_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_trigger", 10, 
+        [generic_relay_node, sub_data_gen, pub_relay](sensor_msgs::msg::Image::UniquePtr /*trigger_msg*/) {
+            RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] Generic Relay: Triggered by /image_trigger.");
+
+            auto img_msg = std::make_shared<sensor_msgs::msg::Image>();
             rclcpp::MessageInfo info;
-            if (sub_data_gen->take_serialized(*msg, info)) {
-                RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] SUCCESS: Pub /image_relay");
-                pub_relay->publish(*msg);
+            
+            // take from sub_data_gen
+            if (sub_data_gen->take(*img_msg, info)) {
+                RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] SUCCESS: Take Success & Pub /image_relay");
+                pub_relay->publish(*img_msg);
             }
         });
 
@@ -83,7 +99,7 @@ int main(int argc, char * argv[]) {
     
     auto sub_data_relay = inter_take_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_relay", 10, [](const sensor_msgs::msg::Image::SharedPtr){}, opt_inter);
-    auto timer_150ms = inter_take_node->create_wall_timer(150ms, [inter_take_node, pub_buffered, sub_data_relay](){
+    auto timer_10ms = inter_take_node->create_wall_timer(10ms, [inter_take_node, pub_buffered, sub_data_relay](){
         sensor_msgs::msg::Image msg; rclcpp::MessageInfo info;
         if (sub_data_relay->take(msg, info)) {
             RCLCPP_INFO(inter_take_node->get_logger(),
@@ -128,7 +144,7 @@ int main(int argc, char * argv[]) {
     
     auto sub_data_latched = timer_take_node->create_subscription<sensor_msgs::msg::Image>(
         "/image_transient_local", transient_local_qos, [](const sensor_msgs::msg::Image::SharedPtr){}, opt_timer);
-    auto timer_cons_100ms = timer_take_node->create_wall_timer(200ms, [timer_take_node, pub_final, sub_data_latched](){
+    auto timer_cons_10ms = timer_take_node->create_wall_timer(10ms, [timer_take_node, pub_final, sub_data_latched](){
         auto msg = std::make_shared<sensor_msgs::msg::Image>();
         rclcpp::MessageInfo info;
         if (sub_data_latched->take(*msg, info)) {

--- a/caret_demos/src/advanced_demo.cpp
+++ b/caret_demos/src/advanced_demo.cpp
@@ -1,210 +1,160 @@
 #include <chrono>
 #include <memory>
-#include <vector>
-#include <random>
 #include <string>
-#include <algorithm>
+#include <vector>
+#include <thread>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/generic_publisher.hpp"
 #include "rclcpp/generic_subscription.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
-#define QOS_HISTORY_SIZE 10
-
 using namespace std::chrono_literals;
 
-std::string spaces(int count) {
-  return std::string(std::max(0, count), ' ');
-}
-
-std::chrono::milliseconds lognormal_distribution(double max)
-{
-  static std::random_device seed_gen;
-  static std::default_random_engine engine(seed_gen());
-  static std::lognormal_distribution<> dist(1.1, 1.7);
-  int sleep_ms = std::max(std::min(dist(engine), max), 20.0);
-  return std::chrono::milliseconds(sleep_ms);
-}
-
-
-class SensorDummy : public rclcpp::Node {
-public:
-  SensorDummy(std::string name, std::string pub_t, int period, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
-  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
-    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
-    timer_ = create_wall_timer(std::chrono::milliseconds(period), [this]() {
-        auto msg = std::make_unique<sensor_msgs::msg::Image>();
-        msg->header.stamp = now();
-        RCLCPP_INFO(this->get_logger(), "%s [Step %d Sensor] Publish >>>", spaces(col_).c_str(), idx_);
-        rclcpp::sleep_for(lognormal_distribution(delay_));
-        pub_->publish(std::move(msg));
-      });
-  }
-private:
-  int idx_, col_; double delay_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
-  rclcpp::TimerBase::SharedPtr timer_;
-};
-
-class GenericRelayNode : public rclcpp::Node {
-public:
-  GenericRelayNode(std::string name, std::string sub_t, std::string pub_t, std::string type, int idx, int col, const rclcpp::NodeOptions & opt)
-  : Node(name, opt), idx_(idx), col_(col) {
-    pub_ = create_generic_publisher(pub_t, type, QOS_HISTORY_SIZE);
-    sub_ = create_generic_subscription(sub_t, type, QOS_HISTORY_SIZE,
-      [this](std::shared_ptr<rclcpp::SerializedMessage> msg) {
-        RCLCPP_INFO(this->get_logger(), "%s [Step %d Generic] Relay", spaces(col_).c_str(), idx_);
-        pub_->publish(*msg);
-      });
-  }
-private:
-  int idx_, col_;
-  rclcpp::GenericPublisher::SharedPtr pub_;
-  rclcpp::GenericSubscription::SharedPtr sub_;
-};
-
-class NoDependencyNode : public rclcpp::Node {
-public:
-  NoDependencyNode(std::string name, std::string sub_t, std::string pub_t, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
-  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
-    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
-    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE,
-      [this](sensor_msgs::msg::Image::UniquePtr msg) {
-        RCLCPP_INFO(this->get_logger(), "%s [Step %d Standard] Callback Received", spaces(col_).c_str(), idx_);
-        rclcpp::sleep_for(lognormal_distribution(delay_));
-        pub_->publish(std::move(msg));
-      });
-  }
-private:
-  int idx_, col_; double delay_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
-};
-
-class TakePollingNode : public rclcpp::Node {
-public:
-  TakePollingNode(std::string name, std::string sub_t, std::string pub_t, std::string trigger_t, int ms, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
-  : Node(name, opt), idx_(idx), col_(col), delay_(delay), received_(false) {
-    pub_ = create_publisher<sensor_msgs::msg::Image>(pub_t, QOS_HISTORY_SIZE);
-    auto group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
-    rclcpp::SubscriptionOptions s_opt; s_opt.callback_group = group;
-    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE, [](sensor_msgs::msg::Image::UniquePtr){}, s_opt);
-    
-    if (trigger_t.empty()) {
-      timer_ = create_wall_timer(std::chrono::milliseconds(ms), [this](){ execute(true); });
-    } else {
-      sub_trig_ = create_subscription<sensor_msgs::msg::Image>(trigger_t, QOS_HISTORY_SIZE, [this](sensor_msgs::msg::Image::UniquePtr){ execute(false); });
-    }
-  }
-private:
-  void execute(bool is_timer) {
-    sensor_msgs::msg::Image msg; rclcpp::MessageInfo info;
-    if (sub_->take(msg, info)) {
-      received_ = true;
-      RCLCPP_INFO(this->get_logger(), "%s [Step %d Take:%s] Success", spaces(col_).c_str(), idx_, is_timer ? "Timer" : "Topic");
-      rclcpp::sleep_for(lognormal_distribution(delay_));
-      pub_->publish(std::make_unique<sensor_msgs::msg::Image>(msg));
-    } else if (is_timer && received_) {
-      RCLCPP_INFO(this->get_logger(), "%s [Step %d Take:Timer] No data", spaces(col_).c_str(), idx_);
-    }
-  }
-  int idx_, col_; double delay_; bool received_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_, sub_trig_;
-  rclcpp::TimerBase::SharedPtr timer_;
-};
-
-class ActuatorDummy : public rclcpp::Node {
-public:
-  ActuatorDummy(std::string name, std::string sub_t, double delay, int idx, int col, const rclcpp::NodeOptions & opt)
-  : Node(name, opt), idx_(idx), col_(col), delay_(delay) {
-    sub_ = create_subscription<sensor_msgs::msg::Image>(sub_t, QOS_HISTORY_SIZE,
-      [this](sensor_msgs::msg::Image::UniquePtr){
-        RCLCPP_INFO(this->get_logger(), "%s [Step %d Actuator] Reached <<<", spaces(col_).c_str(), idx_);
-        rclcpp::sleep_for(lognormal_distribution(delay_));
-      });
-  }
-private:
-  int idx_, col_; double delay_;
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
-};
-
+#define ENABLE_INTRA_PROCESS(options) \
+    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable
 
 int main(int argc, char * argv[]) {
-  rclcpp::init(argc, argv);
-  auto executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-  std::vector<std::shared_ptr<rclcpp::Node>> nodes;
+    rclcpp::init(argc, argv);
 
-  struct NodeBaseConfig {
-    std::string name;
-    std::string sub_t;
-    std::string pub_t;
-    int step;
-    double max_delay;
-  };
+    auto transient_local_qos = rclcpp::QoS(1).reliable().transient_local();
 
-  std::vector<NodeBaseConfig> configs = {
-    {"sensor_dummy_node",       "",             "/topic1",       1,  40.0},
-    {"generic_relay",           "/topic1",      "/topic_gen",    2,   0.0},
-    {"filter_node",             "/topic_gen",   "/topic2",       3, 150.0},
-    {"take_polling_node",       "/topic2",      "/topic_trig",   4,  40.0},
-    {"take_polling_node_timer", "/topic_trig",  "/topic_polled", 5,  40.0},
-    {"actuator_dummy_node",     "/topic_polled", "",             6,  60.0}
-  };
+    // --- Node 1: Sensor Simulator ---
+    auto sensor_simulator_node = std::make_shared<rclcpp::Node>("sensor_simulator_node");
+    auto pub_raw = sensor_simulator_node->create_publisher<sensor_msgs::msg::Image>("/image_raw", 10);
+    auto timer_300ms = sensor_simulator_node->create_wall_timer(300ms, [&](){
+        RCLCPP_INFO(sensor_simulator_node->get_logger(), "[Step 1] Sensor Start: Pub /image_raw (Inter-process) >>>");
+        pub_raw->publish(std::make_unique<sensor_msgs::msg::Image>());
+    });
 
-  // indentation for log
-  size_t max_name_len = 0;
-  for (const auto& c : configs) max_name_len = std::max(max_name_len, c.name.length());
-  auto get_col = [&](const NodeBaseConfig& c) {
-    return static_cast<int>(max_name_len - c.name.length()) + (c.step * 2) + 1;
-  };
+    // --- Node 2: Intra-process Relay ---
+    auto intra_relay_node = std::make_shared<rclcpp::Node>(
+        "intra_relay_node", rclcpp::NodeOptions().use_intra_process_comms(true));
+    auto pub_filtered = intra_relay_node->create_publisher<sensor_msgs::msg::Image>("/image_filtered_intra", 10);
+    auto sub_raw = intra_relay_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_raw", 10, [&](sensor_msgs::msg::Image::UniquePtr msg){
+            RCLCPP_INFO(intra_relay_node->get_logger(),
+                "        [Step 2] Intra Relay: Recv /image_raw -> Pub /image_filtered_intra (Intra-process)");
+            pub_filtered->publish(std::move(msg));
+        });
 
-  rclcpp::NodeOptions intra_on;  intra_on.use_intra_process_comms(true);
-  rclcpp::NodeOptions intra_off; intra_off.use_intra_process_comms(false);
+    // --- Node 3: Data Serializer ---
+    auto data_serializer_node = std::make_shared<rclcpp::Node>("data_serializer_node");
+    auto pub_serialized = data_serializer_node->create_generic_publisher(
+        "/image_serialized", "sensor_msgs/msg/Image", 10);
+    auto sub_filtered = data_serializer_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_filtered_intra", 10, [&](sensor_msgs::msg::Image::UniquePtr msg){
+            RCLCPP_INFO(data_serializer_node->get_logger(),
+                "    [Step 3] Data Serializer: Recv /image_filtered_intra -> Pub Generic /image_serialized");
+            auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
+            rclcpp::Serialization<sensor_msgs::msg::Image> ser;
+            ser.serialize_message(msg.get(), ser_msg.get());
+            pub_serialized->publish(*ser_msg);
+        });
 
-  // Step 1: Sensor (Inter-process)
-  nodes.emplace_back(std::make_shared<SensorDummy>(
-    configs[0].name, configs[0].pub_t, 300, configs[0].max_delay, 
-    configs[0].step, get_col(configs[0]), 
-    intra_off));
+    // --- Node 4: Generic Relay ---
+    auto generic_relay_node = std::make_shared<rclcpp::Node>("generic_relay_node");
+    auto pub_relay = generic_relay_node->create_publisher<sensor_msgs::msg::Image>("/image_relay", 10);
+    auto group_relay = generic_relay_node->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto opt_relay = rclcpp::SubscriptionOptions();
+    opt_relay.callback_group = group_relay;
+    
+    auto sub_data_gen = generic_relay_node->create_generic_subscription(
+        "/image_serialized", "sensor_msgs/msg/Image", 10,
+        [](std::shared_ptr<rclcpp::SerializedMessage>){}, opt_relay);
+    auto sub_trig_gen = generic_relay_node->create_generic_subscription(
+        "/image_serialized", "sensor_msgs/msg/Image", 10, [&](std::shared_ptr<rclcpp::SerializedMessage>){
+            RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] Generic Relay: Triggered by /image_serialized.");
+            auto msg = sub_data_gen->create_serialized_message();
+            rclcpp::MessageInfo info;
+            if (sub_data_gen->take_serialized(*msg, info)) {
+                RCLCPP_INFO(generic_relay_node->get_logger(), "      [Step 4] SUCCESS: Pub /image_relay");
+                pub_relay->publish(*msg);
+            }
+        });
 
-  // Step 2: Generic Relay (Inter-process)
-  nodes.emplace_back(std::make_shared<GenericRelayNode>(
-    configs[1].name, configs[1].sub_t, configs[1].pub_t, "sensor_msgs/msg/Image", 
-    configs[1].step, get_col(configs[1]), 
-    intra_off));
+    // --- Node 5: Inter Take Node ---
+    auto inter_take_node = std::make_shared<rclcpp::Node>("inter_take_node");
+    auto pub_buffered = inter_take_node->create_publisher<sensor_msgs::msg::Image>("/image_inter_buffered", 10);
+    auto group_inter = inter_take_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto opt_inter = rclcpp::SubscriptionOptions();
+    opt_inter.callback_group = group_inter;
+    
+    auto sub_data_relay = inter_take_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_relay", 10, [](const sensor_msgs::msg::Image::SharedPtr){}, opt_inter);
+    auto timer_150ms = inter_take_node->create_wall_timer(150ms, [inter_take_node, pub_buffered, sub_data_relay](){
+        sensor_msgs::msg::Image msg; rclcpp::MessageInfo info;
+        if (sub_data_relay->take(msg, info)) {
+            RCLCPP_INFO(inter_take_node->get_logger(),
+                "         [Step 5] Inter Take Node: Timer triggered take(/image_relay) -> Pub /image_inter_buffered");
+            pub_buffered->publish(msg);
+        }
+    });
 
-  // Step 3: Filter (Inter-process)
-  nodes.emplace_back(std::make_shared<NoDependencyNode>(
-    configs[2].name, configs[2].sub_t, configs[2].pub_t, configs[2].max_delay, 
-    configs[2].step, get_col(configs[2]), 
-    intra_off));
-  
-  // Step 4: Take Topic Trigger (Inter-process)
-  nodes.emplace_back(std::make_shared<TakePollingNode>(
-    configs[3].name, configs[3].sub_t, configs[3].pub_t, "/topic_gen", 100, 
-    configs[3].max_delay, configs[3].step, get_col(configs[3]), 
-    intra_off));
-  
-  // Step 5: Take Polling Timer Trigger (Intra-process)
-  // Receive from Step 4(Inter), and send to Step 6(Intra)
-  nodes.emplace_back(std::make_shared<TakePollingNode>(
-    configs[4].name, configs[4].sub_t, configs[4].pub_t, "", 150, 
-    configs[4].max_delay, configs[4].step, get_col(configs[4]), 
-    intra_on));
-  
-  // Step 6: Actuator (Intra-process)
-  // Receive from Step 5(Intra)
-  nodes.emplace_back(std::make_shared<ActuatorDummy>(
-    configs[5].name, configs[5].sub_t, configs[5].max_delay, 
-    configs[5].step, get_col(configs[5]), 
-    intra_on));
+    // --- Node 6: Intra Take Node ---
+    auto intra_take_node = std::make_shared<rclcpp::Node>(
+        "intra_take_node", rclcpp::NodeOptions().use_intra_process_comms(true));
+    auto pub_latched = intra_take_node->create_publisher<sensor_msgs::msg::Image>(
+        "/image_transient_local", transient_local_qos);
+    auto group_intra = intra_take_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto opt_intra = rclcpp::SubscriptionOptions();
+    opt_intra.callback_group = group_intra;
+    ENABLE_INTRA_PROCESS(opt_intra);
 
-  for (auto & node : nodes) { executor->add_node(node); }
-  
-  RCLCPP_INFO(rclcpp::get_logger("main"), "===== Final Experiment Configuration (Inter x Intra) Started =====");
-  executor->spin();
-  rclcpp::shutdown();
-  return 0;
+    auto sub_data_intra = intra_take_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_filtered_intra", 10, 
+        [pub_latched](const sensor_msgs::msg::Image::SharedPtr msg){ pub_latched->publish(*msg); }, opt_intra);
+
+    auto sub_trig_inter = intra_take_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_inter_buffered", 10, [intra_take_node, sub_data_intra](sensor_msgs::msg::Image::UniquePtr){
+            RCLCPP_INFO(intra_take_node->get_logger(),
+                "         [Step 6] Intra Take Node: Topic triggered take(/image_filtered_intra).");
+            auto ipw = sub_data_intra->get_intra_process_waitable();
+            if (ipw && ipw->is_ready(nullptr)) {
+                auto data = ipw->take_data();
+                if (data && (ipw->execute(data), true)) {
+                    RCLCPP_INFO(intra_take_node->get_logger(), "         [Step 6] SUCCESS: Pub /image_transient_local");
+                }
+            }
+        });
+
+    // --- Node 7: Timer Take Node ---
+    auto timer_take_node = std::make_shared<rclcpp::Node>("timer_take_node");
+    auto pub_final = timer_take_node->create_publisher<sensor_msgs::msg::Image>("/image_final", 10);
+    auto group_timer = timer_take_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto opt_timer = rclcpp::SubscriptionOptions();
+    opt_timer.callback_group = group_timer;
+    
+    auto sub_data_latched = timer_take_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_transient_local", transient_local_qos, [](const sensor_msgs::msg::Image::SharedPtr){}, opt_timer);
+    auto timer_cons_100ms = timer_take_node->create_wall_timer(200ms, [timer_take_node, pub_final, sub_data_latched](){
+        auto msg = std::make_shared<sensor_msgs::msg::Image>();
+        rclcpp::MessageInfo info;
+        if (sub_data_latched->take(*msg, info)) {
+            RCLCPP_INFO(timer_take_node->get_logger(),
+                "         [Step 7] Timer Take Node: Timer triggered take(/image_transient_local) -> Pub /image_final");
+            pub_final->publish(*msg);
+        }
+    });
+
+    // --- Node 8: Dummy Actuator ---
+    auto dummy_actuator_node = std::make_shared<rclcpp::Node>("dummy_actuator_node");
+    auto sub_final = dummy_actuator_node->create_subscription<sensor_msgs::msg::Image>(
+        "/image_final", 10, [&](const sensor_msgs::msg::Image::SharedPtr){
+            RCLCPP_INFO(dummy_actuator_node->get_logger(), "     [Step 8] Dummy Actuator: Recv /image_final. Path Complete! <<<");
+        });
+
+    // --- Execution ---
+    std::vector<std::shared_ptr<rclcpp::Node>> nodes = {
+        sensor_simulator_node, intra_relay_node, data_serializer_node,
+        generic_relay_node, inter_take_node, intra_take_node,
+        timer_take_node, dummy_actuator_node
+    };
+    std::vector<std::thread> threads;
+    for (auto node : nodes) { threads.emplace_back([node]() { rclcpp::spin(node); }); }
+    for (auto & thread : threads) { thread.join(); }
+
+    rclcpp::shutdown();
+    return 0;
 }


### PR DESCRIPTION
Created the following path as advanced_demo. Supports intra/inter communication, generic communication, and topic reception via take() (both topic and timer triggers).

### Node-to-Node Communication Paths
No | Node Name | In → Out | Communication Type | Operational Details |
-- | -- | -- | -- | -- |
1 | sensor_simulator_node | (Timer) → /image_raw | Inter-process | Initiates standard communication triggered by a 100ms timer. 
2 | intra_relay_node | /image_raw → /image_filtered_intra | Intra-process | Performs high-speed relaying via intra-process communication. 
3 | data_serializer_node | /image_filtered_intra → /image_serialized, /image_trigger | Generic / Serialized | Serializes messages for generic publishing; also publishes a trigger topic. 
4 | generic_relay_node | /image_serialized (Trigger: /image_trigger) → /image_relay | Generic Take | Uses the trigger topic to manually fetch serialized data via take_serialized(). 
5 | inter_take_node | /image_relay → /image_inter_buffered | Timer Take | Executes take() on a 10ms timer cycle to pull data from the queue. 
6 | intra_take_node | /image_filtered_intra (Trigger: /image_inter_buffered) → /image_transient_local | Intra-process Waitable | Utilizes IntraProcessWaitable for low-latency manual data acquisition. 
7 | timer_take_node | /image_transient_local → /image_final | Latched Take | Periodically fetches data with Transient Local (latching) QoS via timer. 
8 | dummy_actuator_node | /image_final → (Log) | Standard Sub | Confirms the final data arrival (marks the completion of the path). 
